### PR TITLE
Made IgnoreOwners and IgnoreAdmins. Removed usage of string methamethods. A minor bugfix. Important syntax fix.

### DIFF
--- a/src/Server/BoboFighter/Constants.lua
+++ b/src/Server/BoboFighter/Constants.lua
@@ -1,5 +1,6 @@
 return {
 	PASSIVE_CHECK_INTERVAL = .2,
 	SMALL_DECIMAL = 1e-5, 
-	INVALID_ARGUMENT_FORMAT = "Bad argument to #%s, expected %s, got %s"
+	INVALID_ARGUMENT_FORMAT = "Bad argument to #%s, expected %s, got %s",
+	MAX_GROUPINFO_TRIES = 10
 }

--- a/src/Server/BoboFighter/Settings.lua
+++ b/src/Server/BoboFighter/Settings.lua
@@ -11,8 +11,8 @@ return {
 		InvalidHatDrop = true, -- Hats being dropped invalidly
 	},
 
-	-- List of user id's that will be black listed (won't be detected)
-	BlackListedPlayers = {
+	-- List of user id's that will be whitelisted (won't be detected)
+	WhiteListedPlayers = {
 		--[[  
 			[125390463] = true,
 		]]

--- a/src/Server/BoboFighter/Settings.lua
+++ b/src/Server/BoboFighter/Settings.lua
@@ -18,6 +18,9 @@ return {
 		]]
 	},
 
+	IgnoreOwners = true, -- If game owners are whitelisted from the anti cheat
+	IgnoreAdmins = true, -- If admins are whitelisted from the anti cheat
+
 	Leeways = {
 		-- Lower leeways than these may result in false positives! You're encouraged to test them out though and see 
 		-- which one is best suited for your game

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -396,7 +396,7 @@ function BoboFighter.Connect()
 			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0)
 			or _G.CommanderAPI and _G.CommanderAPI.checkAdmin and _G.CommanderAPI.checkAdmin:Invoke(player))
 		then
-			return	
+			return
 		end
 
 

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -322,7 +322,7 @@ function BoboFighter.Connect()
 				end
 
 				-- Make sure the child is a tool and isn't a part of the player's backpack:
-				if (not child:IsA("BackpackItem")) or child.Parent == player.Backpack then
+				if (not child:IsA("BackpackItem")) or child.Parent == player:FindFirstChildOfClass("Backpack") then
 					return
 				end
 

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -381,16 +381,22 @@ function BoboFighter.Connect()
 		end
 	end
 
-	local GotGroupOwnerId = 0
-	coroutine.wrap(xpcall)(function()
+	local gotGroupOwnerId = 0
+	coroutine.wrap(function()
 		if game.CreatorType == Enum.CreatorType.Group then
-			GotGroupOwnerId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+			local tries = 0
+			repeat
+				xpcall(function()
+					gotGroupOwnerId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+				end, warn)
+				tries += 1
+			until gotGroupOwnerId and gotGroupOwnerId ~= 0 or tries > Constants.MAX_GROUPINFO_TRIES
 		end
-	end, warn)
+	end)()
 
 	local function PlayerAdded(player)
 		if 
-			Settings.IgnoreOwners == true and (game.CreatorId == player.UserId and game.CreatorType == Enum.CreatorType.User or game.CreatorType == Enum.CreatorType.Group and GotGroupOwnerId == player.UserId)
+			Settings.IgnoreOwners == true and (game.CreatorId == player.UserId and game.CreatorType == Enum.CreatorType.User or game.CreatorType == Enum.CreatorType.Group and gotGroupOwnerId == player.UserId)
 			or Settings.IgnoreAdmins and (
 			_G.Adonis and _G.Adonis.CheckAdmin and _G.Adonis.CheckAdmin(player)
 			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and (_G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0))

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -390,6 +390,7 @@ function BoboFighter.Connect()
 					gotGroupOwnerId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
 				end, warn)
 				tries += 1
+				RunService.Heartbeat:Wait()
 			until gotGroupOwnerId and gotGroupOwnerId ~= 0 or tries > Constants.MAX_GROUPINFO_TRIES
 		end
 	end)()

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -67,14 +67,14 @@ local function Child_Destroyed(child)
 		child.Parent = child
 	end)
 
-	return result:match("locked")
+	return string.match(result, "locked")
 end
 
 local function HeartbeatUpdate()
 	BoboFighter.HeartbeatUpdate = RunService.Heartbeat:Connect(function()
 		for _, player in ipairs(Players:GetPlayers()) do
-			-- Is player black listed?
-			if Settings.BlackListedPlayers[player.UserId] then
+			-- Is player whitelisted?
+			if Settings.WhiteListedPlayers[player.UserId] then
 				continue
 			end
 
@@ -144,7 +144,7 @@ local function HeartbeatUpdate()
 						if depth >= leeways.NoClipDepth then
 							Punish(primaryPart, physicsData.LastCFrame)
 							exploitData.TimeSincePunished = os.clock()
-							table.insert(exploitData.Detections, ("No Clip | Captured depth: %s"):format(depth))
+							table.insert(exploitData.Detections, string.format("No Clip | Captured depth: %s", depth))
 						end 
 
 					elseif not ray then
@@ -156,7 +156,7 @@ local function HeartbeatUpdate()
 							Punish(primaryPart, primaryPart.CFrame * CFrame.new(0, 0, 3))
 							exploitData.TimeSincePunished = os.clock()
 							exploitData.Flags += 1
-							table.insert(exploitData.Detections, ("No Clip | Captured depth: %s"):format(depth))
+							table.insert(exploitData.Detections, string.format("No Clip | Captured depth: %s", depth))
 						end
 					end
 				end
@@ -183,7 +183,7 @@ local function HeartbeatUpdate()
 						Punish(primaryPart, physicsData.LastCFrame)
 						exploitData.TimeSincePunished = os.clock()
 						exploitData.Flags += 1
-						table.insert(exploitData.Detections, ("Speeding | Captured average speed: %s"):format(averageSpeed))
+						table.insert(exploitData.Detections, string.format("Speeding | Captured average speed: %s", averageSpeed))
 					end
 				end
 			end
@@ -210,7 +210,7 @@ local function HeartbeatUpdate()
 							Punish(primaryPart, physicsData.LastCFrame)
 							exploitData.TimeSincePunished = os.clock()
 							exploitData.Flags += 1
-							table.insert(exploitData.Detections, ("Vertical Speeding | Captured jump power: %s"):format(accumulatedJumpPower))
+							table.insert(exploitData.Detections, string.format("Vertical Speeding | Captured jump power: %s", accumulatedJumpPower))
 						end
 					end
 				end
@@ -442,7 +442,7 @@ end
 
 function BoboFighter.Disconnect()
 	if not BoboFighter.HeartbeatConnection then
-		return warn(("%s No current connections"):format(tostring(BoboFighter)))
+		return warn(string.format("%s No current connections", tostring(BoboFighter)))
 	end
 
 	BoboFighter.HeartbeatConnection:Disconnect()

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -384,7 +384,7 @@ function BoboFighter.Connect()
 	local GotGroupOwnerId = 0
 	coroutine.wrap(xpcall)(function()
 		if game.CreatorType == Enum.CreatorType.Group then
-			GroupedId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+			GotGroupOwnerId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
 		end
 	end, warn)
 

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -393,7 +393,7 @@ function BoboFighter.Connect()
 			Settings.IgnoreOwners == true and (game.CreatorId == player.UserId and game.CreatorType == Enum.CreatorType.User or game.CreatorType == Enum.CreatorType.Group and GotGroupOwnerId == player.UserId)
 			or Settings.IgnoreAdmins and (
 			_G.Adonis and _G.Adonis.CheckAdmin and _G.Adonis.CheckAdmin(player)
-			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0)
+			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0)
 			or _G.CommanderAPI and _G.CommanderAPI.checkAdmin and _G.CommanderAPI.checkAdmin:Invoke(player))
 		then
 			return	

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -1,4 +1,4 @@
--[[
+--[[
     BoboFighter Version 1.6 - Beta
 ]]
 

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -393,7 +393,7 @@ function BoboFighter.Connect()
 			Settings.IgnoreOwners == true and (game.CreatorId == player.UserId and game.CreatorType == Enum.CreatorType.User or game.CreatorType == Enum.CreatorType.Group and GotGroupOwnerId == player.UserId)
 			or Settings.IgnoreAdmins and (
 			_G.Adonis and _G.Adonis.CheckAdmin and _G.Adonis.CheckAdmin(player)
-			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0)
+			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and (_G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0))
 			or _G.CommanderAPI and _G.CommanderAPI.checkAdmin and _G.CommanderAPI.checkAdmin:Invoke(player))
 		then
 			return

--- a/src/Server/BoboFighter/init.lua
+++ b/src/Server/BoboFighter/init.lua
@@ -12,6 +12,7 @@ end})
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
+local GroupService = game:GetService("GroupService")
 
 assert(script:FindFirstChild("Settings"), "Settings module not found")
 assert(script:FindFirstChild("Constants"), "Constants module not found")
@@ -380,7 +381,25 @@ function BoboFighter.Connect()
 		end
 	end
 
+	local GotGroupOwnerId = 0
+	coroutine.wrap(xpcall)(function()
+		if game.CreatorType == Enum.CreatorType.Group then
+			GroupedId = GroupService:GetGroupInfoAsync(game.CreatorId).Owner.Id
+		end
+	end, warn)
+
 	local function PlayerAdded(player)
+		if 
+			Settings.IgnoreOwners == true and (game.CreatorId == player.UserId and game.CreatorType == Enum.CreatorType.User or game.CreatorType == Enum.CreatorType.Group and GotGroupOwnerId == player.UserId)
+			or Settings.IgnoreAdmins and (
+			_G.Adonis and _G.Adonis.CheckAdmin and _G.Adonis.CheckAdmin(player)
+			or _G.HDAdminMain and _G.HDAdminMain:GetModule("API") and _G.HDAdminMain:GetModule("API"):GetRank(player) > (_G.HDAdminMain:GetModule("API"):GetRankId("nonadmins") or 0)
+			or _G.CommanderAPI and _G.CommanderAPI.checkAdmin and _G.CommanderAPI.checkAdmin:Invoke(player))
+		then
+			return	
+		end
+
+
 		-- Reliable way of firing CharacterAdded event properly:
 		CharacterAdded(player, player.Character or player.CharacterAdded:Wait())
 


### PR DESCRIPTION
Added IgnoreOwners and IgnoreAdmins. IgnoreOwners ignores the place owner and admins admins if an admin command system is present. Supported Admin commands. Adonis Admin, HD Admin and Commander.

Removed usage of string methamethods as they are not very idiomatic and have bad performance expecially in Lua's version Luau

Fixed a minor bug with backpacks.

Also fixed invalid syntax preventing bobofighter from running